### PR TITLE
Fixed maxplayers command not checking if arena was already in-game

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 1.1.5 Release (26.08.2021 - XX)
 * Fixed build check outside of arena border was checking for player and not for block location
+* Fixed maxplayers command not checking if arena was already in-game
 
 ### 1.1.4 Release (19.07.2021 - 01.08.2021)
 * Reuse XMaterial for specialitems

--- a/pom.xml
+++ b/pom.xml
@@ -272,6 +272,17 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- External beta versions discord deployer plugin -->
+            <plugin>
+                <groupId>plugily.projects</groupId>
+                <artifactId>betty-maven-plugin</artifactId>
+                <version>1.0.2</version>
+                <configuration>
+                    <changelogFile>${project.basedir}/CHANGELOG.md</changelogFile>
+                </configuration>
+            </plugin>
+            <!-- External beta versions discord deployer plugin -->
         </plugins>
         <extensions>
             <extension>

--- a/pom.xml
+++ b/pom.xml
@@ -272,17 +272,6 @@
                     </execution>
                 </executions>
             </plugin>
-
-            <!-- External beta versions discord deployer plugin -->
-            <plugin>
-                <groupId>plugily.projects</groupId>
-                <artifactId>betty-maven-plugin</artifactId>
-                <version>1.0.2</version>
-                <configuration>
-                    <changelogFile>${project.basedir}/CHANGELOG.md</changelogFile>
-                </configuration>
-            </plugin>
-            <!-- External beta versions discord deployer plugin -->
         </plugins>
         <extensions>
             <extension>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>plugily.projects</groupId>
     <artifactId>thebridge</artifactId>
-    <version>1.1.4-dev1</version>
+    <version>1.1.4-dev2</version>
     <name>TheBridge</name>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>plugily.projects</groupId>
     <artifactId>thebridge</artifactId>
-    <version>1.1.4-dev0</version>
+    <version>1.1.4-dev1</version>
     <name>TheBridge</name>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>plugily.projects</groupId>
     <artifactId>thebridge</artifactId>
-    <version>1.1.4-dev3</version>
+    <version>1.1.4-dev4</version>
     <name>TheBridge</name>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>plugily.projects</groupId>
     <artifactId>thebridge</artifactId>
-    <version>1.1.4-dev2</version>
+    <version>1.1.4-dev3</version>
     <name>TheBridge</name>
 
     <properties>

--- a/src/main/java/plugily/projects/thebridge/commands/arguments/game/JoinArguments.java
+++ b/src/main/java/plugily/projects/thebridge/commands/arguments/game/JoinArguments.java
@@ -60,6 +60,7 @@ public class JoinArguments {
           List<Arena> arenaList = new ArrayList<>();
           Map<Arena, Integer> arenas = new HashMap<>();
           for(Arena arena : ArenaRegistry.getArenas()) {
+            if(!(arena.getArenaState() == ArenaState.WAITING_FOR_PLAYERS || arena.getArenaState() == ArenaState.STARTING)) continue;
             arenas.put(arena, arena.getPlayers().size());
           }
           if(args.length == 3) {
@@ -70,6 +71,7 @@ public class JoinArguments {
             }
             arenas.clear();
             for(Arena arena : ArenaRegistry.getArenas()) {
+              if(!(arena.getArenaState() == ArenaState.WAITING_FOR_PLAYERS || arena.getArenaState() == ArenaState.STARTING)) continue;
               if(arena.getBases().get(0).getMaximumSize() == Integer.parseInt(args[2])) {
                 arenas.put(arena, arena.getPlayers().size());
                 arenaList.add(arena);


### PR DESCRIPTION
Fixed maxplayers command not checking if arena was already in-game

checks if the arena is in waiting for players or starting state before considering it for the maxplayers option