### PR TITLE
fix: player base not removed

### DIFF
--- a/src/main/java/plugily/projects/thebridge/arena/ArenaManager.java
+++ b/src/main/java/plugily/projects/thebridge/arena/ArenaManager.java
@@ -64,6 +64,10 @@ public class ArenaManager extends PluginArenaManager {
     if(pluginArena == null) {
       return;
     }
+    Base base = pluginArena.getBase(player);
+    if(base != null){
+      base.removePlayer(player);
+    }
     super.leaveAttempt(player, arena);
     if(pluginArena.isDeathPlayer(player)) {
       pluginArena.removeDeathPlayer(player);


### PR DESCRIPTION
fixed player join a base, then quit game will not remove the player in the base. (will cause base still have this player and occupied a slot)